### PR TITLE
Adding CORS headers for options request.

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -100,7 +100,7 @@ class CreateUploadUrlHandler(webapp2.RequestHandler):
 
 class UploadFileOnServerHandler(webapp2.RequestHandler):
 
-    def options(self, bucket=None):
+    def options(self):
         self.response.headers['Access-Control-Allow-Origin'] = '*'
         self.response.headers['Access-Control-Allow-Methods'] = 'POST'
         self.response.headers['Access-Control-Max-Age'] = 86400

--- a/backend/main.py
+++ b/backend/main.py
@@ -91,7 +91,7 @@ class UploadHandler(blobstore_handlers.BlobstoreUploadHandler):
 class CreateUploadUrlHandler(webapp2.RequestHandler):
 
     def options(self):
-        add_cors_headers(self.response)
+        add_cors_headers(self.response, 'GET')
 
     def get(self, bucket=None):
         bucket = bucket or BUCKET_NAME

--- a/backend/main.py
+++ b/backend/main.py
@@ -103,7 +103,7 @@ class UploadFileOnServerHandler(webapp2.RequestHandler):
     def options(self):
         self.response.headers['Access-Control-Allow-Origin'] = '*'
         self.response.headers['Access-Control-Allow-Methods'] = 'POST'
-        self.response.headers['Access-Control-Max-Age'] = 86400
+        self.response.headers['Access-Control-Max-Age'] = '86400'
 
     def post(self, bucket=None):
         bucket = bucket or BUCKET_NAME

--- a/backend/main.py
+++ b/backend/main.py
@@ -100,6 +100,11 @@ class CreateUploadUrlHandler(webapp2.RequestHandler):
 
 class UploadFileOnServerHandler(webapp2.RequestHandler):
 
+    def options(self, bucket=None):
+        self.response.headers['Access-Control-Allow-Origin'] = '*'
+        self.response.headers['Access-Control-Allow-Methods'] = 'POST'
+        self.response.headers['Access-Control-Max-Age'] = 86400
+
     def post(self, bucket=None):
         bucket = bucket or BUCKET_NAME
         uploaded_content = self.request.POST.multi['file'].file.read()

--- a/backend/main.py
+++ b/backend/main.py
@@ -53,6 +53,11 @@ class UploadedImage(ndb.Model):
     path = ndb.StringProperty(repeated=True)
 
 
+def add_cors_headers(response, methods='POST'):
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Methods'] = methods
+    response.headers['Access-Control-Max-Age'] = '86400'
+
 
 class UploadCallbackHandler(blobstore_handlers.BlobstoreUploadHandler):
 
@@ -85,6 +90,9 @@ class UploadHandler(blobstore_handlers.BlobstoreUploadHandler):
 
 class CreateUploadUrlHandler(webapp2.RequestHandler):
 
+    def options(self):
+        add_cors_headers(self.response)
+
     def get(self, bucket=None):
         bucket = bucket or BUCKET_NAME
         gs_bucket_name = '{}/{}'.format(bucket, FOLDER)
@@ -101,9 +109,7 @@ class CreateUploadUrlHandler(webapp2.RequestHandler):
 class UploadFileOnServerHandler(webapp2.RequestHandler):
 
     def options(self):
-        self.response.headers['Access-Control-Allow-Origin'] = '*'
-        self.response.headers['Access-Control-Allow-Methods'] = 'POST'
-        self.response.headers['Access-Control-Max-Age'] = '86400'
+        add_cors_headers(self.response)
 
     def post(self, bucket=None):
         bucket = bucket or BUCKET_NAME


### PR DESCRIPTION
Browsers do a prefetch (OPTIONS) request to see if the url supports the CORS. (see https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request)

Adding an OPTIONS request for the file uploader to see if that fixes the blocked CORS requests.